### PR TITLE
Early return when checking toJson invoke in List items

### DIFF
--- a/lib/src/router_plus/response_handler/json_handler.dart
+++ b/lib/src/router_plus/response_handler/json_handler.dart
@@ -20,20 +20,7 @@ ResponseHandler get jsonHandler => (Request request, dynamic data) {
 
       /// Serialize lists
       if (data is List<dynamic>) {
-        /// Try to invoke '.toJson()' on every item
-        final invokeList = data
-            .map((item) => _invokeToJsonMethod(item))
-            .toList(growable: false);
-
-        /// Everytime item successfully transformed via '.toJson'?
-        var everyItemIsToJsonInvokable =
-            invokeList.every((item) => item != null);
-
-        if (everyItemIsToJsonInvokable) {
-          return invokeList;
-        } else {
-          return _serializedJsonResponse(data);
-        }
+        return _handleListResponse(data);
       }
 
       /// Handle Iterable by turning them into lists (process with next iteration)
@@ -61,6 +48,29 @@ Object? _invokeToJsonMethod(dynamic object) {
     }
   }
   return null;
+}
+
+Object? _handleListResponse(List<dynamic> data) {
+  final invokeList = List<Object?>.filled(data.length, null, growable: false);
+
+  /// Try to invoke '.toJson()' on every item
+  var everyItemIsToJsonInvokable = true;
+
+  for (var i = 0; i < data.length; i++) {
+    final item = data[i];
+    final json = _invokeToJsonMethod(item);
+    if (json == null) {
+      everyItemIsToJsonInvokable = false;
+      break;
+    }
+    invokeList[i] = json;
+  }
+
+  if (everyItemIsToJsonInvokable) {
+    return invokeList;
+  } else {
+    return _serializedJsonResponse(data);
+  }
 }
 
 // TODO serialize Iterable<Person>


### PR DESCRIPTION
Hey there! I was looking at the new feature you've added for handling list responses as json and I saw that the code tries to run `toJson` on all items in the list even if the any of them doesn't match.
This change may be negligible in terms of performance, but maybe it could add up with bigger lists and many requests. Every failure involves a dynamic method call, a try catch and a String contains.

Before:
![image](https://user-images.githubusercontent.com/22084723/117272179-36d33380-ae5b-11eb-9a5d-8210cf439490.png)

After:
![image](https://user-images.githubusercontent.com/22084723/117272196-3aff5100-ae5b-11eb-9b21-939951767267.png)

Let me know what you think.
Thanks for the work on the package!