### PR TITLE
Add test for nested ShelfPlusApp with middlewares

### DIFF
--- a/test/router_plus_test.dart
+++ b/test/router_plus_test.dart
@@ -315,6 +315,29 @@ void main() {
 
     expect(receivedData, ['open', 'message: websocket']);
   });
+
+  test('middlewares scoped to router', () async {
+    var restrictedApp = Router().plus;
+    restrictedApp.use(
+      (innerHandler) => (Request request) async {
+        fail('Should not trigger this middleware');
+      },
+    );
+    restrictedApp.get('/protected', () => 'protected data');
+
+    var app = Router().plus;
+    
+    app.mount('/', restrictedApp);
+
+    app.get('/public', () {
+      return 'public data';
+    });
+
+    server = await runTestServer(app);
+
+    var r = await server.fetch('get', '/public');
+    expect(r.data, 'public data');
+  });
 }
 
 class Cat {


### PR DESCRIPTION
Hello @felixblaschke !
I noticed a breaking behavior after updating the library.
Since commit f184f4771504f7babfb5b3ad5214197fe5cfaf8e the behavior in the regression test I added here does not work correctly.

I'm using that behavior to group routes that share a middleware, and then I mount them in the main `app`.

Is this breaking behavior working as intended?
