### PR TITLE
🚀 Implemented `onStartFailed` call back in `shelf_run.dart`.

### DIFF
--- a/lib/src/shelf_run.dart
+++ b/lib/src/shelf_run.dart
@@ -50,13 +50,11 @@ Future<ShelfRunContext> shelfRun(
           onStarted: onStarted,
         );
         context._server = server;
-      }
-      on SocketException catch(e){
-        if(onStartFailed != null) {
+      } on SocketException catch (e) {
+        if (onStartFailed != null) {
           onStartFailed.call(e);
-        }
-        else{
-          print(e);
+        } else {
+          rethrow;
         }
       }
       return Future.value(context._server);
@@ -71,13 +69,11 @@ Future<ShelfRunContext> shelfRun(
         securityContext: securityContext,
         onStarted: onStarted,
       );
-    }
-    on SocketException catch(e){
-      if(onStartFailed != null) {
+    } on SocketException catch (e) {
+      if (onStartFailed != null) {
         onStartFailed.call(e);
-      }
-      else{
-        print(e);
+      } else {
+        rethrow;
       }
     }
   }

--- a/test/shelf_run_test.dart
+++ b/test/shelf_run_test.dart
@@ -74,6 +74,45 @@ void main() {
     await ctx.close();
   });
 
+  test('shelf run - test onStartFailed behavior , hot reload off', () async {
+    var init = () => (Request request) => Response.ok('ok');
+
+    String? failed;
+    var ctx = await shelfRun(
+      init,
+      defaultEnableHotReload: false,
+      defaultBindAddress: "10.10.10.10",
+      onStartFailed: (e) {
+        failed = "FAILED";
+      },
+    );
+
+    expect(failed, isNotNull);
+
+    await ctx.close();
+  });
+
+  test('shelf run - test onStartFailed behavior , hot reload on', () async {
+    var init = () => (Request request) => Response.ok('ok');
+
+    String? failed;
+    var ctx = await shelfRun(
+      init,
+      defaultEnableHotReload: false,
+      defaultBindAddress: "10.10.10.10",
+      onStartFailed: (e) {
+        failed = "FAILED";
+      },
+    );
+
+    /// wait for server warm up when hot reload enabled.
+    await Future.delayed(Duration(seconds: 1));
+
+    expect(failed, isNotNull);
+
+    await ctx.close();
+  });
+
   test('shelf run - isolates / shared', () async {
     var ctxList = <ShelfRunContext>[];
 


### PR DESCRIPTION
@felixblaschke 
This Fixes #27 .
Hey There!
This commit adds support for `onStartFailed` call back in `shelfRun()` function. This enables us to know if the server was crashed due to any `SocketException` that occurs during Initialization. Since, `shelfRun` process is an asynchronized  operation, it was not externally possible to handle the exception that occurs during initializatiion. But this commit, enables you to handle it via the `onStartFailed` call back! Heres, an example call:
```dart
void main(){
    shelfRun(init, onStartFailed: (e) => print("An error occured during server initilization"));
}
```