### PR TITLE
Fix CORS example

### DIFF
--- a/example/example_cors/bin/example_cors.dart
+++ b/example/example_cors/bin/example_cors.dart
@@ -4,11 +4,11 @@ import 'package:shelf_plus/shelf_plus.dart';
 void main() => shelfRun(init);
 
 Handler init() {
-  var app = Router().plus;
+  final router = Router().plus;
 
-  app.use(corsHeaders()); // use CORS middleware
+  router.get('/', () => {'data': 'This API is CORS enabled.'});
 
-  app.get('/', () => {'data': 'This API is CORS enabled.'});
+  final app = Pipeline().addMiddleware(corsHeaders()).addHandler(router);
 
   return app;
 }


### PR DESCRIPTION
Remove corsHeader() from router
Add corsHeader() to Pipeline()

Previous example didn't handle OPTIONS requests that are a part of CORS implementation

shelf_plus Router can't add middleware to non-specified routes ( by design ), so the best implementation is adding Pipeline with middleware "before" shelf_plus router. 
