### PR TITLE
Revert "use stdout.println instead of print"

### DIFF
--- a/lib/src/shelf_run.dart
+++ b/lib/src/shelf_run.dart
@@ -103,7 +103,7 @@ Future<HttpServer> _createServer(
   final server = await io.serve(handler, address, port,
       shared: shared, securityContext: securityContext);
   if (onStarted == null) {
-    stdout.writeln('shelfRun HTTP service running on port ${server.port}');
+    print('shelfRun HTTP service running on port ${server.port}');
   } else {
     onStarted(address, port);
   }


### PR DESCRIPTION
This reverts commit 79bc7c6a05474f559998635989a81315ddd929f6, because `writeln` is not thread-safe. See https://github.com/dart-lang/sdk/issues/55345 for more details. Resolves #37 .