### PR TITLE
Upgrade dependencies to allow latest

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,12 +11,12 @@ dependencies:
   shelf_router: ^1.1.4
   shelf_static: ^1.1.2
   shelf_hotreload: ^1.5.0
-  shelf_web_socket: ^1.0.4
+  shelf_web_socket: ">=1.0.4 <3.0.0"
   mime_type: ^1.0.0
-  web_socket_channel: ^2.4.4
+  web_socket_channel: ">=2.4.4 <4.0.0"
 
 dev_dependencies:
-  lints: ^3.0.0
+  lints: ^5.0.0
   test: ^1.25.2
   dio: ^5.4.1
   json_annotation: ^4.8.1


### PR DESCRIPTION
Facing some pub upgrade issues in my project, so need to allow latest version of some dependencies.

The tests seem to pass so does not appear like there are any breaking changes.